### PR TITLE
Fuzz by writing temp file and calling CmdExtract::DoExtract()

### DIFF
--- a/projects/unrar/build.sh
+++ b/projects/unrar/build.sh
@@ -19,5 +19,48 @@ set -eu
 
 tar xf $SRC/unrarsrc-5.5.8.tar.gz
 
-# build project
-make -C $SRC/unrar/unrar lib
+# build 'lib'. This builds libunrar.a and libunrar.so
+# -fPIC is required for successful compilation.
+make CXX=$CXX CXXFLAGS="$CXXFLAGS -fPIC" -C $SRC/unrar/unrar lib
+
+# remove the .so file so that the linker links unrar statically.
+rm -v $SRC/unrar/unrar/libunrar.so
+
+cat <<HERE > $SRC/unrar/unrar_fuzzer.cc
+#include <memory>
+#include <stddef.h>
+#include <string>
+#include <unistd.h>
+
+#include "unrar/rar.hpp"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  char filename[] = "mytemp.XXXXXX";
+  int fd = mkstemp(filename);
+  write(fd, data, size);
+
+  std::unique_ptr<CommandData> cmd_data(new CommandData);
+  cmd_data->ParseArg(const_cast<wchar_t *>(L"-p"));
+  cmd_data->ParseArg(const_cast<wchar_t *>(L"x"));
+  cmd_data->ParseDone();
+  std::wstring wide_filename(filename, filename + strlen(filename));
+  cmd_data->AddArcName(wide_filename.c_str());
+
+  try {
+    CmdExtract extractor(cmd_data.get());
+    extractor.DoExtract();
+  } catch (...) {
+  }
+
+  close(fd);
+  unlink(filename);
+
+  return 0;
+}
+HERE
+
+# build fuzzer
+$CXX $CXXFLAGS -v -g -ggdb -std=c++11 -I. \
+     $SRC/unrar/unrar_fuzzer.cc -o $OUT/unrar_fuzzer \
+     -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DRAR_SMP -DRARDLL \
+     -lFuzzingEngine -L$SRC/unrar/unrar -lunrar -lstdc++


### PR DESCRIPTION
It could be made better by:
* Use ```git clone``` instead of unpacking a tar.gz file
* Have ```unrar_fuzzer.cc``` as a separate file in some repo, instead of creating it using HERE document.